### PR TITLE
go-git/go-git library for the werf project

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -47,6 +47,7 @@ var (
 
 	ErrInvalidReference          = errors.New("invalid reference, should be a tag or a branch")
 	ErrRepositoryNotExists       = errors.New("repository does not exist")
+	ErrRepositoryIncomplete      = errors.New("repository's commondir path does not exist")
 	ErrRepositoryAlreadyExists   = errors.New("repository already exists")
 	ErrRemoteNotFound            = errors.New("remote not found")
 	ErrRemoteExists              = errors.New("remote already exists")
@@ -253,7 +254,13 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		return nil, err
 	}
 
-	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	options := filesystem.Options{}
+	options.Commonfs, err = dotGitCommonDirectory(dot)
+	if err != nil {
+		return nil, err
+	}
+
+	s := filesystem.NewStorageWithOptions(dot, cache.NewObjectLRUDefault(), options)
 
 	return Open(s, wt)
 }
@@ -326,6 +333,38 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Files
 	}
 
 	return osfs.New(fs.Join(path, gitdir)), nil
+}
+
+func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err error) {
+	f, err := fs.Open("commondir")
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := stdioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > 0 {
+		path := strings.TrimSpace(string(b))
+		if filepath.IsAbs(path) {
+			commonDir = osfs.New(path)
+		} else {
+			commonDir = osfs.New(filepath.Join(fs.Root(), path))
+		}
+		if _, err := commonDir.Stat(""); err != nil {
+			if os.IsNotExist(err) {
+				return nil, ErrRepositoryIncomplete
+			}
+
+			return nil, err
+		}
+	}
+
+	return commonDir, nil
 }
 
 // PlainClone a repository into the path with the given options, isBare defines

--- a/storage/filesystem/dotgit/dotgit_setref.go
+++ b/storage/filesystem/dotgit/dotgit_setref.go
@@ -25,7 +25,7 @@ func (d *DotGit) setRefRwfs(fileName, content string, old *plumbing.Reference) (
 		mode |= os.O_TRUNC
 	}
 
-	f, err := d.fs.OpenFile(fileName, mode, 0666)
+	f, err := d.fsFromRefPath(fileName).OpenFile(fileName, mode, 0666)
 	if err != nil {
 		return err
 	}
@@ -59,9 +59,11 @@ func (d *DotGit) setRefRwfs(fileName, content string, old *plumbing.Reference) (
 // making it compatible with these simple filesystems. This is usually not
 // a problem as they should be accessed by only one process at a time.
 func (d *DotGit) setRefNorwfs(fileName, content string, old *plumbing.Reference) error {
-	_, err := d.fs.Stat(fileName)
+	fs := d.fsFromRefPath(fileName)
+
+	_, err := fs.Stat(fileName)
 	if err == nil && old != nil {
-		fRead, err := d.fs.Open(fileName)
+		fRead, err := fs.Open(fileName)
 		if err != nil {
 			return err
 		}
@@ -78,7 +80,7 @@ func (d *DotGit) setRefNorwfs(fileName, content string, old *plumbing.Reference)
 		}
 	}
 
-	f, err := d.fs.Create(fileName)
+	f, err := fs.Create(fileName)
 	if err != nil {
 		return err
 	}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -12,8 +12,9 @@ import (
 // standard git format (this is, the .git directory). Zero values of this type
 // are not safe to use, see the NewStorage function below.
 type Storage struct {
-	fs  billy.Filesystem
-	dir *dotgit.DotGit
+	fs       billy.Filesystem
+	commonfs billy.Filesystem
+	dir      *dotgit.DotGit
 
 	ObjectStorage
 	ReferenceStorage
@@ -34,6 +35,9 @@ type Options struct {
 	// MaxOpenDescriptors is the max number of file descriptors to keep
 	// open. If KeepDescriptors is true, all file descriptors will remain open.
 	MaxOpenDescriptors int
+	// CommonDir sets the directory used for accessing non-worktree files that
+	// would normally be taken from the root directory.
+	Commonfs billy.Filesystem
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -46,12 +50,15 @@ func NewStorage(fs billy.Filesystem, cache cache.Object) *Storage {
 func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options) *Storage {
 	dirOps := dotgit.Options{
 		ExclusiveAccess: ops.ExclusiveAccess,
+		KeepDescriptors: ops.KeepDescriptors,
 	}
-	dir := dotgit.NewWithOptions(fs, dirOps)
+
+	dir := dotgit.NewWithOptions(fs, ops.Commonfs, dirOps)
 
 	return &Storage{
-		fs:  fs,
-		dir: dir,
+		fs:       fs,
+		commonfs: ops.Commonfs,
+		dir:      dir,
 
 		ObjectStorage:    *NewObjectStorageWithOptions(dir, cache, ops),
 		ReferenceStorage: ReferenceStorage{dir: dir},
@@ -65,6 +72,12 @@ func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options)
 // Filesystem returns the underlying filesystem
 func (s *Storage) Filesystem() billy.Filesystem {
 	return s.fs
+}
+
+// CommonFilesystem returns the underlying filesystem for the main
+// working-tree/common git directory
+func (s *Storage) CommonFilesystem() billy.Filesystem {
+	return s.commonfs
 }
 
 // Init initializes .git directory

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2006,3 +2006,78 @@ func (s *WorktreeSuite) TestAddAndCommit(c *C) {
 	})
 	c.Assert(err, IsNil)
 }
+
+func (s *WorktreeSuite) TestLinkedWorktree(c *C) {
+	fs := fixtures.ByTag("linked-worktree").One().Worktree()
+
+	// Open main repo.
+	{
+		fs, err := fs.Chroot("main")
+		c.Assert(err, IsNil)
+		repo, err := PlainOpen(fs.Root())
+		c.Assert(err, IsNil)
+
+		wt, err := repo.Worktree()
+		c.Assert(err, IsNil)
+
+		status, err := wt.Status()
+		c.Assert(err, IsNil)
+		c.Assert(len(status), Equals, 2) // 2 files
+
+		head, err := repo.Head()
+		c.Assert(err, IsNil)
+		c.Assert(string(head.Name()), Equals, "refs/heads/master")
+	}
+
+	// Open linked-worktree #1.
+	{
+		fs, err := fs.Chroot("linked-worktree-1")
+		c.Assert(err, IsNil)
+		repo, err := PlainOpen(fs.Root())
+		c.Assert(err, IsNil)
+
+		wt, err := repo.Worktree()
+		c.Assert(err, IsNil)
+
+		status, err := wt.Status()
+		c.Assert(err, IsNil)
+		c.Assert(len(status), Equals, 3) // 3 files
+
+		_, ok := status["linked-worktree-1-unique-file.txt"]
+		c.Assert(ok, Equals, true)
+
+		head, err := repo.Head()
+		c.Assert(err, IsNil)
+		c.Assert(string(head.Name()), Equals, "refs/heads/linked-worktree-1")
+	}
+
+	// Open linked-worktree #2.
+	{
+		fs, err := fs.Chroot("linked-worktree-2")
+		c.Assert(err, IsNil)
+		repo, err := PlainOpen(fs.Root())
+		c.Assert(err, IsNil)
+
+		wt, err := repo.Worktree()
+		c.Assert(err, IsNil)
+
+		status, err := wt.Status()
+		c.Assert(err, IsNil)
+		c.Assert(len(status), Equals, 3) // 3 files
+
+		_, ok := status["linked-worktree-2-unique-file.txt"]
+		c.Assert(ok, Equals, true)
+
+		head, err := repo.Head()
+		c.Assert(err, IsNil)
+		c.Assert(string(head.Name()), Equals, "refs/heads/branch-with-different-name")
+	}
+
+	// Open linked-worktree #2.
+	{
+		fs, err := fs.Chroot("linked-worktree-invalid-commondir")
+		c.Assert(err, IsNil)
+		_, err = PlainOpen(fs.Root())
+		c.Assert(err, Equals, ErrRepositoryIncomplete)
+	}
+}


### PR DESCRIPTION
This PR contains changes to the upstream go-git code, which needeed for [the werf project](https://github.com/werf/werf).